### PR TITLE
More reusable Feed component

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -342,7 +342,7 @@
 					<scramble-text intersection="true"> News </scramble-text>
 				</h3>
 
-				<news-feed></news-feed>
+				<news-feed src="https://www.ilico.org/wp-json/wp/v2"></news-feed>
 
 			</section>
 			<section id="about" class="mb-80">

--- a/packages/components/src/Articles/Feed.ts
+++ b/packages/components/src/Articles/Feed.ts
@@ -1,4 +1,4 @@
-import Consumer from "app/src/news/consumer.ts";
+import Consumer from './consumer.ts';
 
 const html = `
 <style>
@@ -20,6 +20,8 @@ class Feed extends HTMLElement {
     static readonly name = 'news-feed';
     readonly shadowRoot: ShadowRoot;
     readonly consumer: Consumer;
+    baseUrl: string = '';
+    static observedAttributes = ['src'];
 
 
     constructor() {
@@ -31,24 +33,28 @@ class Feed extends HTMLElement {
         this.consumer = new Consumer();
     }
 
-    async connectedCallback() {
-        const posts = await this.consumer.getData();
-
-        // Create a list element
+    async connectedCallback(){
+        const posts = await this.consumer.getData(this.baseUrl);
         const list = document.createElement('ul');
-
-        // For each post, create a list item with title and excerpt
         posts.slice(0, 3).forEach(post => {
             const item = document.createElement('li');
             item.innerHTML = `
-        <h5><a href="${post.link}" target="_blank" rel="noopener noreferrer">${post.title}</a></h5>
-        <div>${post.excerpt}</div>
+        <h5>
+            <a href="${post.link}" target="_blank" rel="noopener noreferrer">${post.title}</a>
+        </h5>
+        <p>${post.excerpt}</p>
       `;
             list.appendChild(item);
         });
-
-        // Clear any old content and append the list
         this.shadowRoot.append(list);
+    }
+
+    // @ts-ignore
+    attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+        if (name === 'src') {
+            this.baseUrl = newValue;
+            return;
+        }
     }
 }
 

--- a/packages/components/src/Articles/consumer.ts
+++ b/packages/components/src/Articles/consumer.ts
@@ -39,20 +39,15 @@ type Post = {
 };
 
 class Consumer {
-    readonly isDev;
-    readonly baseUrl
 
     constructor() {
-        this.isDev = import.meta.env.DEV;
-        this.baseUrl = this.isDev ? 'https://www.ilico.org/wp-json/wp/v2' : '/wp-json/wp/v2';
+
     }
 
-    async getData(): Promise<Post[]> {
-        const storage = localStorage.getItem('posts');
-        if (storage == null) {
-            let datas: Response = await fetch(`${this.baseUrl}/posts`);
+    async getData(baseUrl: string): Promise<Post[]> {
+            let datas: Response = await fetch(`${baseUrl}/posts`);
             const json = (await datas.clone().json()) as WpPost[];
-            const datasParsed: Post[] = json
+        return json
                 .filter((o) => o.status === 'publish')
                 .map((o) => {
                     return {
@@ -69,10 +64,7 @@ class Consumer {
                         tags: o.tags,
                     };
                 });
-            localStorage.setItem('posts', JSON.stringify(datasParsed));
-            return datasParsed;
 
-        } else return (JSON.parse(storage)) as Post[];
     }
 
 }


### PR DESCRIPTION
Base url is now written in an HTML file, in an observed 'src' attribute of the corresponding component.